### PR TITLE
fix-margins

### DIFF
--- a/src/css/our-products.css
+++ b/src/css/our-products.css
@@ -22,12 +22,18 @@
   text-transform: uppercase;
   color: var(--black-firs-color);
 }
+@media only screen and (min-width: 768px) {
+  .our-products-title {
+    margin-bottom: 50px;
+    font-size: 24px;
+    line-height: 1.17;
+  }
+}
 .our-products-title-accent {
   color: var(--orange-color);
 }
 
 .our-products-container-taste {
-  margin-bottom: 20px;
   padding: 32px 52px;
   text-align: center;
 
@@ -52,6 +58,7 @@
 .our-products-img {
   margin-bottom: 8px;
 }
+
 .our-products-title-taste {
   margin-bottom: 2px;
   font-weight: 600;

--- a/src/css/slider.css
+++ b/src/css/slider.css
@@ -16,12 +16,11 @@
 
 .swiper-wrapper {
   display: flex;
-  margin-bottom: 20px;
+  margin-bottom: 40px;
 }
-
 @media only screen and (min-width: 768px) {
   .swiper-wrapper {
-    margin-bottom: 32px;
+    margin-bottom: 52px;
   }
 }
 

--- a/src/partials/our-products.html
+++ b/src/partials/our-products.html
@@ -92,7 +92,7 @@
                 ./img/our-products/classic-milk.png    1x,
                 ./img/our-products/classic-milk@2x.png 2x
               "
-              src="./img/our-products/classic.png"
+              src="./img/our-products/classic-milk.png"
               alt="CLASSIC"
               width="230"
               height="201"


### PR DESCRIPTION
Влад, щоб не пробивати дочірній елемент, як казала Сівоненко, я задала на swiper-wrapper відступ margin-bottom: 40px(на таблет і десктопі 52px відповідно), хоча на макеті 20 на мобілці і 32 на таблет і десктопі. Як задаю 20px, то пагінація прижимається до низу картинки. Це видно, що на пагінацію абсолют стоїть. Візуально виглядає як на макеті. Може так лишити?